### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ else ifneq ($(findstring Darwin,$(UNAME)),)
 endif
 
 TARGET_NAME	:= gpsp
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 LIBM		   := -lm
 CORE_DIR    := .
 LDFLAGS     :=

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 LOCAL_MODULE    := retro
 CPU_ARCH        :=
 

--- a/libretro.c
+++ b/libretro.c
@@ -116,7 +116,10 @@ extern struct retro_perf_callback perf_cb;
 void retro_get_system_info(struct retro_system_info* info)
 {
    info->library_name = "gpSP";
-   info->library_version = "v0.91";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "v0.91" GIT_VERSION;
    info->need_fullpath = true;
    info->block_extract = false;
    info->valid_extensions = "gba|bin|agb|gbz" ;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.