### PR TITLE
Allow compiling android jni for all archs

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,2 @@
 NDK_TOOLCHAIN_VERSION := 4.9
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86
+APP_ABI := all


### PR DESCRIPTION
Will not compile with clang, so toolchain override must remain.