### PR TITLE
Update libretro.c: Add missing input descriptors

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -414,6 +414,8 @@ static void set_input_descriptors()
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "A" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT,   "Select" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,    "Start" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L, "L" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "R" },
       { 0 },
    };
 


### PR DESCRIPTION
gpSP is missing L and R descriptors as shown here.

https://github.com/libretro/gpsp/blob/434612ab6824bca0d3e88d0b7135b8a9ffc12061/libretro.c#L408-L418

https://github.com/libretro/gpsp/blob/434612ab6824bca0d3e88d0b7135b8a9ffc12061/input.h#L46-L57

This commit adds the missing L and R descriptors.

Compiled and tested successfully on Windows 10 x64.