### PR TITLE
Fix compilation for PSP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,10 @@ else ifeq ($(platform), psp1)
 	CC = psp-gcc$(EXE_EXT)
 	AR = psp-ar$(EXE_EXT)
 	CFLAGS += -DPSP -G0
+	CFLAGS += -I$(shell psp-config --pspsdk-path)/include
+	CFLAGS += -march=allegrex -mfp32 -mgp32 -mlong32 -mabi=eabi
+	CFLAGS += -fomit-frame-pointer -ffast-math -fstrict-aliasing
+	CFLAGS += -falign-functions=32 -falign-loops -falign-labels -falign-jumps
 	STATIC_LINKING = 1
 
 # Vita

--- a/libco/libco.c
+++ b/libco/libco.c
@@ -12,6 +12,8 @@
   #include "ppc.c"
 #elif defined(VITA)
   #include "scefiber.c"
+#elif defined(PSP)
+  #include "psp1.c"
 #elif defined(__GNUC__) && defined(__aarch64__)
   #include "aarch64.c"
 #elif defined(__GNUC__) && (defined(__ARM_EABI__) || defined(__arm__))

--- a/libco/psp1.c
+++ b/libco/psp1.c
@@ -1,0 +1,45 @@
+#define LIBCO_C
+#include "libco.h"
+
+#include <stdlib.h>
+#include <pspthreadman.h>
+
+/* Since cothread_t is a void pointer it must contain an address. We can't return a reference to a local variable
+ * because it would go out of scope, so we create a static variable instead so we can return a reference to it.
+ */
+static SceUID active_thread_id = 0;
+
+cothread_t co_active()
+{
+  active_thread_id = sceKernelGetThreadId();
+  return &active_thread_id;
+}
+
+cothread_t co_create(unsigned int size, void (*entrypoint)(void))
+{
+  /* Similar scenario as with active_thread_id except there will only be one active_thread_id while there could be many
+   * new threads each with their own handle, so we create them on the heap instead and delete them manually when they're
+   * no longer needed in co_delete().
+   */
+  cothread_t handle = malloc(sizeof(cothread_t));
+
+  /* SceKernelThreadEntry has a different signature than entrypoint, but in practice this seems to work */
+  SceUID new_thread_id = sceKernelCreateThread("cothread", (SceKernelThreadEntry)entrypoint, 0x12, size, 0, NULL);
+  sceKernelStartThread(new_thread_id, 0, NULL);
+
+  *(SceUID *)handle = new_thread_id;
+  return handle;
+}
+
+void co_delete(cothread_t handle)
+{
+  sceKernelTerminateDeleteThread(*(SceUID *)handle);
+  free(handle);
+}
+
+void co_switch(cothread_t handle)
+{
+  sceKernelWakeupThread(*(SceUID *)handle);
+  /* Sleep the currently active thread so the new thread can start */
+  sceKernelSleepThread();
+}


### PR DESCRIPTION
Since this core was originally an emulator for the PSP, it seems only fitting to get it working for the PSP again :)

First of all, it needed a PSP implementation of libco.

Secondly, it needed the path to the headers from the PSP SDK.

As always, this is way out of my area of expertise so please feel free to modify the code as needed.

The core is still too slow to be playable on the PSP, but one thing at a time...

Thanks!