### PR TITLE
[3DS] Fix dynarec prefetch aborts

### DIFF
--- a/3ds/3ds_cache_utils.S
+++ b/3ds/3ds_cache_utils.S
@@ -1,0 +1,25 @@
+  .text
+  .arm
+  .balign 4
+
+  .func ctr_clear_cache_kernel
+ctr_clear_cache_kernel:
+  cpsid aif
+  mov r0, #0
+  mcr p15, 0, r0, c7, c10, 0    @ Clean entire data cache
+  mcr p15, 0, r0, c7, c10, 5    @ Data Memory Barrier
+  mcr p15, 0, r0, c7, c5, 0     @ Invalidate entire instruction cache / Flush BTB
+  mcr p15, 0, r0, c7, c10, 4    @ Data Sync Barrier
+  bx lr
+  .endfunc
+
+  @@ Clear the entire data cache / invalidate the instruction cache. Uses
+  @@ Rosalina svcCustomBackdoor to avoid svcBackdoor stack corruption
+  @@ during interrupts.
+  .global ctr_clear_cache
+  .func ctr_clear_cache
+ctr_clear_cache:
+  ldr r0, =ctr_clear_cache_kernel
+  svc 0x80                      @ svcCustomBackdoor
+  bx lr
+  .endfunc

--- a/3ds/3ds_utils.c
+++ b/3ds/3ds_utils.c
@@ -7,6 +7,20 @@
 
 typedef s32 (*ctr_callback_type)(void);
 
+void check_rosalina() {
+  int64_t version;
+  uint32_t major;
+
+  has_rosalina = false;
+
+  if (!svcGetSystemInfo(&version, 0x10000, 0)) {
+     major = GET_VERSION_MAJOR(version);
+
+     if (major >= 8)
+       has_rosalina = true;
+  }
+}
+
 static void ctr_invalidate_ICache_kernel(void)
 {
    __asm__ volatile(
@@ -38,6 +52,10 @@ void ctr_flush_DCache(void)
 
 void ctr_flush_invalidate_cache(void)
 {
-   ctr_flush_DCache();
-   ctr_invalidate_ICache();
+   if (has_rosalina) {
+      ctr_clear_cache();
+   } else {
+      ctr_flush_DCache();
+      ctr_invalidate_ICache();
+   }
 }

--- a/3ds/3ds_utils.h
+++ b/3ds/3ds_utils.h
@@ -7,6 +7,10 @@ void ctr_flush_invalidate_cache(void);
 
 extern __attribute((weak)) unsigned int __ctr_svchax;
 
+bool has_rosalina;
+void check_rosalina();
+void ctr_clear_cache(void);
+
 void wait_for_input();
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 #define DEBUG_VAR(X) printf( "%-20s: 0x%08X\n", #X, (u32)(X))

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,6 @@ else ifeq ($(platform), ctr)
 	CFLAGS += -fomit-frame-pointer -ffast-math
 	CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 	CPU_ARCH := arm
-	# dynarec unavailable with the HBL on FW > 9.2
 	HAVE_DYNAREC = 1
 	STATIC_LINKING = 1
 
@@ -469,7 +468,7 @@ endif
 
 ifeq ($(platform), ctr)
 ifeq ($(HAVE_DYNAREC), 1)
-OBJECTS += 3ds/3ds_utils.o
+OBJECTS += 3ds/3ds_utils.o 3ds/3ds_cache_utils.o
 
 ifeq ($(strip $(CTRULIB)),)
 $(error "Please set CTRULIB in your environment. export CTRULIB=<path to>ctrulib")

--- a/libretro.c
+++ b/libretro.c
@@ -185,6 +185,8 @@ void retro_init(void)
    if (__ctr_svchax && !translation_caches_inited)
    {
       uint32_t currentHandle;
+      check_rosalina();
+      
       rom_translation_cache_ptr  = memalign(0x1000, ROM_TRANSLATION_CACHE_SIZE);
       ram_translation_cache_ptr  = memalign(0x1000, RAM_TRANSLATION_CACHE_SIZE);
       bios_translation_cache_ptr = memalign(0x1000, BIOS_TRANSLATION_CACHE_SIZE);


### PR DESCRIPTION
Similar fix to https://github.com/libretro/pcsx_rearmed/pull/390. The Nintendo svcBackdoor can cause stack corruption if an interrupt happens during it, this uses Luma3DS/Rosalina's svcCustomBackdoor instead.

With this patch, I haven't experienced any ingame crashes. However, when switching between games, there are still user-mode data aborts in the dynarec. This patch should still improve stability quite a bit.