### PR TITLE
[3DS] Move has_rosalina to avoid duplicate definitions

### DIFF
--- a/3ds/3ds_utils.c
+++ b/3ds/3ds_utils.c
@@ -6,6 +6,7 @@
 #include "3ds_utils.h"
 
 typedef s32 (*ctr_callback_type)(void);
+static bool has_rosalina;
 
 void check_rosalina() {
   int64_t version;

--- a/3ds/3ds_utils.h
+++ b/3ds/3ds_utils.h
@@ -7,7 +7,6 @@ void ctr_flush_invalidate_cache(void);
 
 extern __attribute((weak)) unsigned int __ctr_svchax;
 
-bool has_rosalina;
 void check_rosalina();
 void ctr_clear_cache(void);
 


### PR DESCRIPTION
This avoids an error when building under GCC 10, and should not affect earlier versions.