### PR TITLE
Fix ARM dynarec

### DIFF
--- a/arm/arm_emit.h
+++ b/arm/arm_emit.h
@@ -174,7 +174,7 @@ s32 arm_register_allocation[] =
   reg_x4,       /* GBA r12 */
   mem_reg,      /* GBA r13 */
   reg_x5,       /* GBA r14 */
-  reg_a0        /* GBA r15 */
+  mem_reg,      /* GBA r15 */
 
   mem_reg,
   mem_reg,
@@ -211,7 +211,7 @@ s32 thumb_register_allocation[] =
   mem_reg,      /* GBA r12 */
   mem_reg,      /* GBA r13 */
   mem_reg,      /* GBA r14 */
-  reg_a0        /* GBA r15 */
+  mem_reg,      /* GBA r15 */
 
   mem_reg,
   mem_reg,

--- a/arm/arm_emit.h
+++ b/arm/arm_emit.h
@@ -174,7 +174,7 @@ s32 arm_register_allocation[] =
   reg_x4,       /* GBA r12 */
   mem_reg,      /* GBA r13 */
   reg_x5,       /* GBA r14 */
-  mem_reg,      /* GBA r15 */
+  reg_a0,       /* GBA r15 */
 
   mem_reg,
   mem_reg,
@@ -211,7 +211,7 @@ s32 thumb_register_allocation[] =
   mem_reg,      /* GBA r12 */
   mem_reg,      /* GBA r13 */
   mem_reg,      /* GBA r14 */
-  mem_reg,      /* GBA r15 */
+  reg_a0,       /* GBA r15 */
 
   mem_reg,
   mem_reg,

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -272,17 +272,11 @@ extern u8 bit_count[256];
 #define invalidate_icache_region(addr, size) (void)0
 
 #elif defined(ARM_ARCH)
-static int sys_cacheflush(void *addr, unsigned long size)
+static void sys_cacheflush(void *addr, unsigned long size)
 {
    void *start = (void*)addr;
    void *end   = (void*)(char *)addr + size;
-
-	register const unsigned char *r0 asm("r0") = start;
-	register const unsigned char *r1 asm("r1") = end;
-	register const int r2 asm("r2") = 0;
-	register const int r7 asm("r7") = 0xf0002;
-	asm volatile ("svc 0x0" :: "r" (r0), "r" (r1), "r" (r2), "r" (r7));
-   return -1;
+   __clear_cache(start, end);
 }
 
 #define translate_invalidate_dcache_one(which)                                \


### PR DESCRIPTION
Turns out there were a couple of very interesting and hard to track
bugs. A missing comma made the reg list too short, leaving the 31th
element at the mercy of the linker ordering algorithm, which seems to
work in some cases depending on the compiler version.
Also the cache flush code seemed not to work on my machine (OGA),
not sure why it wored in the past :/