### PR TITLE
Small fixes to division by zero

### DIFF
--- a/gba_memory.c
+++ b/gba_memory.c
@@ -199,7 +199,7 @@ static void sound_control_x(u32 value)
 
 #define sound_update_frequency_step(timer_number)                             \
   timer[timer_number].frequency_step =                                        \
-   float_to_fp8_24(GBC_BASE_RATE / (timer_reload * sound_frequency))          \
+   float_to_fp8_24((GBC_BASE_RATE / sound_frequency) / (timer_reload))        \
 
 /* Main */
 extern timer_type timer[4];

--- a/sound.c
+++ b/sound.c
@@ -273,8 +273,11 @@ u32 gbc_sound_master_volume;
       else                                                                    \
         rate = rate + (rate >> gs->sweep_shift);                              \
                                                                               \
-      if(rate > 2048)                                                         \
-        rate = 2048;                                                          \
+      if(rate > 2047) {                                                       \
+        rate = 2047;                                                          \
+        gs->active_flag = 0;                                                  \
+        break;                                                                \
+      }                                                                       \
                                                                               \
       frequency_step = float_to_fp16_16(((131072.0f / (2048 - rate)) * 8.0f)  \
        / sound_frequency);                                                    \


### PR DESCRIPTION
This causes crashes in PSP quite often in many games. Other CPUs might
(depending on the processor state) silently return zero or some
undefined value.
The fix is borrowed from ReGBA's codebase