### PR TITLE
Remove PSP-specific stuff from MIPS backend

### DIFF
--- a/common.h
+++ b/common.h
@@ -65,31 +65,8 @@
   #include <pspaudiolib.h>
   #include <psprtc.h>
 
-  #define convert_palette(value)                                              \
-    value = ((value & 0x7FE0) << 1) | (value & 0x1F)                          \
-
-  #define psp_file_open_read  PSP_O_RDONLY
-  #define psp_file_open_write (PSP_O_CREAT | PSP_O_WRONLY | PSP_O_TRUNC)
-
-  #define file_open(filename_tag, filename, mode)                             \
-    s32 filename_tag = sceIoOpen(filename, psp_file_open_##mode, 0777)        \
-
-  #define file_check_valid(filename_tag)                                      \
-    (filename_tag >= 0)                                                       \
-
-  #define file_close(filename_tag)                                            \
-    sceIoClose(filename_tag)                                                  \
-
-  #define file_read(filename_tag, buffer, size)                               \
-    sceIoRead(filename_tag, buffer, size)                                     \
-
-  #define file_write(filename_tag, buffer, size)                              \
-    sceIoWrite(filename_tag, buffer, size)                                    \
-
-  #define file_seek(filename_tag, offset, type)                               \
-    sceIoLseek(filename_tag, offset, PSP_##type)                              \
-
-  #define file_tag_type s32
+  #define convert_palette(value)  \
+    value = ((value & 0x7FE0) << 1) | (value & 0x1F)
 
   #include <time.h>
 #else
@@ -103,55 +80,14 @@
   typedef unsigned long long int u64;
   typedef signed long long int s64;
 
-  #define convert_palette(value)                                              \
-    value = ((value & 0x1F) << 11) | ((value & 0x03E0) << 1) | (value >> 10)  \
-
-  #define stdio_file_open_read  "rb"
-  #define stdio_file_open_write "wb"
-
-  #define file_open(filename_tag, filename, mode)                             \
-    FILE *filename_tag = fopen(filename, stdio_file_open_##mode)              \
-
-  #define file_check_valid(filename_tag)                                      \
-    (filename_tag)                                                            \
-
-  #define file_close(filename_tag)                                            \
-    fclose(filename_tag)                                                      \
-
-  #define file_read(filename_tag, buffer, size)                               \
-    fread(buffer, 1, size, filename_tag)                                      \
-
-  #define file_write(filename_tag, buffer, size)                              \
-    fwrite(buffer, 1, size, filename_tag)                                     \
-
-  #define file_seek(filename_tag, offset, type)                               \
-    fseek(filename_tag, offset, type)                                         \
-
-  #define file_tag_type FILE *
+  #define convert_palette(value) \
+    value = ((value & 0x1F) << 11) | ((value & 0x03E0) << 1) | (value >> 10)
 
 #endif
 
 #define GBA_SCREEN_WIDTH  (240)
 #define GBA_SCREEN_HEIGHT (160)
 #define GBA_SCREEN_PITCH  (240)
-
-// These must be variables, not constants.
-
-#define file_read_variable(filename_tag, variable)                            \
-  file_read(filename_tag, &variable, sizeof(variable))                        \
-
-#define file_write_variable(filename_tag, variable)                           \
-  file_write(filename_tag, &variable, sizeof(variable))                       \
-
-// These must be statically declared arrays (ie, global or on the stack,
-// not dynamically allocated on the heap)
-
-#define file_read_array(filename_tag, array)                                  \
-  file_read(filename_tag, array, sizeof(array))                               \
-
-#define file_write_array(filename_tag, array)                                 \
-  file_write(filename_tag, array, sizeof(array))                              \
-
 
 
 typedef u32 fixed16_16;

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -3793,18 +3793,18 @@ void flush_translation_cache_bios(void)
 
 void dump_translation_cache(void)
 {
-  file_open(ram_cache, cache_dump_prefix "ram_cache.bin", write);
-  file_write(ram_cache, ram_translation_cache,
-   ram_translation_ptr - ram_translation_cache);
-  file_close(ram_cache);
+  FILE *fd = fopen(cache_dump_prefix "ram_cache.bin", "wb");
+  fwrite(ram_translation_cache, 1,
+   ram_translation_ptr - ram_translation_cache, fd);
+  fclose(fd);
 
-  file_open(rom_cache, cache_dump_prefix "rom_cache.bin", write);
-  file_write(rom_cache, rom_translation_cache,
-   rom_translation_ptr - rom_translation_cache);
-  file_close(rom_cache);
+  fd = fopen(cache_dump_prefix "rom_cache.bin", "wb");
+  fwrite(rom_translation_cache, 1,
+   rom_translation_ptr - rom_translation_cache, fd);
+  fclose(fd);
 
-  file_open(bios_cache, cache_dump_prefix "bios_cache.bin", write);
-  file_write(bios_cache, bios_translation_cache,
-   bios_translation_ptr - bios_translation_cache);
-  file_close(bios_cache);
+  fd = fopen(cache_dump_prefix "bios_cache.bin", "wb");
+  fwrite(bios_translation_cache, 1,
+   bios_translation_ptr - bios_translation_cache, fd);
+  fclose(fd);
 }

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -2362,7 +2362,7 @@ static s32 load_gamepak_raw(const char *name)
 
     // First, close the last one if it was open, we won't
     // be needing it anymore.
-    if(!gamepak_file_large)
+    if(gamepak_file_large)
       fclose(gamepak_file_large);
 
     // If it's a big file size keep it, don't close it, we'll

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -343,15 +343,7 @@ gamepak_swap_entry_type *gamepak_memory_map;
 // This is global so that it can be kept open for large ROMs to swap
 // pages from, so there's no slowdown with opening and closing the file
 // a lot.
-#ifdef PSP
-
-file_tag_type gamepak_file_large = -1;
-
-#else
-
-file_tag_type gamepak_file_large = NULL;
-
-#endif
+FILE *gamepak_file_large = NULL;
 
 u32 direct_map_vram = 0;
 
@@ -2050,15 +2042,14 @@ char backup_filename[512];
 
 u32 load_backup(char *name)
 {
-  file_open(backup_file, name, read);
+  FILE *fd = fopen(name, "rb");
 
-  if(file_check_valid(backup_file))
+  if(fd)
   {
-    u32 backup_size = file_length(name, backup_file);
+    u32 backup_size = file_length(fd);
 
-    file_read(backup_file, gamepak_backup, backup_size);
-
-    file_close(backup_file);
+    fread(gamepak_backup, 1, backup_size, fd);
+    fclose(fd);
 
     // The size might give away what kind of backup it is.
     switch(backup_size)
@@ -2104,9 +2095,9 @@ u32 save_backup(char *name)
 {
   if(backup_type != BACKUP_NONE)
   {
-    file_open(backup_file, name, write);
+    FILE *fd = fopen(name, "wb");
 
-    if(file_check_valid(backup_file))
+    if(fd)
     {
       u32 backup_size = 0;
 
@@ -2137,9 +2128,8 @@ u32 save_backup(char *name)
           break;
       }
 
-      file_write(backup_file, gamepak_backup, backup_size);
-
-      file_close(backup_file);
+      fwrite(gamepak_backup, 1, backup_size, fd);
+      fclose(fd);
       return 1;
     }
   }
@@ -2364,36 +2354,31 @@ static s32 load_game_config(char *gamepak_title, char *gamepak_code, char *gamep
 
 static s32 load_gamepak_raw(const char *name)
 {
-  file_open(gamepak_file, name, read);
+  FILE *fd = fopen(name, "rb");
 
-  if(file_check_valid(gamepak_file))
+  if(fd)
   {
-    u32 file_size = file_length(name, gamepak_file);
+    u32 file_size = file_length(fd);
 
     // First, close the last one if it was open, we won't
     // be needing it anymore.
-    if(file_check_valid(gamepak_file_large))
-      file_close(gamepak_file_large);
+    if(!gamepak_file_large)
+      fclose(gamepak_file_large);
 
     // If it's a big file size keep it, don't close it, we'll
     // probably want to load from it more later.
     if(file_size <= gamepak_ram_buffer_size)
     {
-      file_read(gamepak_file, gamepak_rom, file_size);
+      fread(gamepak_rom, 1, file_size, fd);
+      fclose(fd);
 
-      file_close(gamepak_file);
-
-#ifdef PSP
-      gamepak_file_large = -1;
-#else
       gamepak_file_large = NULL;
-#endif
     }
     else
     {
       // Read in just enough for the header
-      file_read(gamepak_file, gamepak_rom, 0x100);
-      gamepak_file_large = gamepak_file;
+      fread(gamepak_rom, 1, 0x100, fd);
+      gamepak_file_large = fd;
     }
 
     return file_size;
@@ -2460,16 +2445,16 @@ u32 load_gamepak(const struct retro_game_info* info, const char *name)
 
 s32 load_bios(char *name)
 {
-  file_open(bios_file, name, read);
+  FILE *fd = fopen(name, "rb");
 
-  if(!(file_check_valid(bios_file)))
+  if(!fd)
     return -1;
 
-  file_read(bios_file, bios_rom, 0x4000);
+  fread(bios_rom, 1, 0x4000, fd);
 
   // This is a hack to get Zelda working, because emulating
   // the proper memory read behavior here is much too expensive.
-  file_close(bios_file);
+  fclose(fd);
   return 0;
 }
 
@@ -3187,8 +3172,8 @@ u8 *load_gamepak_page(u32 physical_index)
   gamepak_memory_map[page_index].physical_index = physical_index;
   page_time++;
 
-  file_seek(gamepak_file_large, physical_index * (32 * 1024), SEEK_SET);
-  file_read(gamepak_file_large, swap_location, (32 * 1024));
+  fseek(gamepak_file_large, physical_index * (32 * 1024), SEEK_SET);
+  fread(swap_location, 1, (32 * 1024), gamepak_file_large);
   memory_map_read[(0x8000000 / (32 * 1024)) + physical_index] = swap_location;
   memory_map_read[(0xA000000 / (32 * 1024)) + physical_index] = swap_location;
   memory_map_read[(0xC000000 / (32 * 1024)) + physical_index] = swap_location;
@@ -3374,9 +3359,10 @@ void init_memory(void)
 
 void memory_term(void)
 {
-  if (file_check_valid(gamepak_file_large))
+  if (gamepak_file_large)
   {
-    file_close(gamepak_file_large);
+    fclose(gamepak_file_large);
+    gamepak_file_large = NULL;
   }
 
   if (gamepak_memory_map)

--- a/main.c
+++ b/main.c
@@ -281,14 +281,7 @@ void reset_gba(void)
   reset_sound();
 }
 
-#ifdef PSP
-u32 file_length(const char *filename, s32 dummy)
-{
-  SceIoStat stats;
-  sceIoGetstat(filename, &stats);
-  return stats.st_size;
-#else
-u32 file_length(const char *dummy, FILE *fp)
+u32 file_length(FILE *fp)
 {
   u32 length;
 
@@ -297,7 +290,6 @@ u32 file_length(const char *dummy, FILE *fp)
   fseek(fp, 0, SEEK_SET);
 
   return length;
-#endif
 }
 
 void change_ext(const char *src, char *buffer, const char *extension)

--- a/main.h
+++ b/main.h
@@ -94,11 +94,7 @@ void main_write_savestate(void);
 void main_read_savestate(void);
 
 
-#ifdef PSP
-u32 file_length(const char *filename, s32 dummy);
-#else
-u32 file_length(const char *dummy, FILE *fp);
-#endif
+u32 file_length(FILE *fp);
 
 extern u32 num_skipped_frames;
 extern int dynarec_enable;


### PR DESCRIPTION
This is unnecessary since newlib supports all file I/O.
This is needed for other mips ports