### PR TITLE
Ensure post processing configuration is correctly reset in retro_deinit()

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -545,6 +545,8 @@ void retro_deinit(void)
    gba_processed_pixels   = NULL;
    gba_screen_pixels_prev = NULL;
    video_post_process     = NULL;
+   post_process_cc        = false;
+   post_process_mix       = false;
 }
 
 static retro_time_t retro_perf_dummy_get_time_usec() { return 0; }


### PR DESCRIPTION
At present, the second time that content is loaded with the core on dynamic platforms, the `Color Correction` and `Interframe Blending` options are ignored (i.e. they are always set to disabled). This is a previously hidden bug (which should never occur on dynamic platforms...), and it seems to be platform-dependent: the core has always functioned correctly in the past, and it still functions correctly on half my devices. It is likely that an OS (glibc) update has revealed the underlying issue...

This PR simply ensures that the video post processing configuration is properly reset inside retro_deinit(). This 'forces' correct initialisation each time the core is loaded.