### PR TITLE
Remove BIOS reserved translation area

### DIFF
--- a/arm/arm_stub.S
+++ b/arm/arm_stub.S
@@ -440,8 +440,6 @@ _execute_swi_##mode:                                                          ;\
   orr r0, r0, #0x13                       /* set to supervisor mode        */;\
   str r0, [reg_base, #REG_CPSR]           /* update cpsr                   */;\
                                                                              ;\
-  call_c_function(bios_region_read_allow)                                    ;\
-                                                                             ;\
   mov r0, #MODE_SUPERVISOR                                                   ;\
                                                                              ;\
   store_registers_##mode()                /* store regs for mode           */;\

--- a/cpu.c
+++ b/cpu.c
@@ -1639,8 +1639,6 @@ void raise_interrupt(irq_type irq_raised)
     reg[REG_CPSR] = 0xD2;
     reg[REG_PC] = 0x00000018;
 
-    bios_region_read_allow();
-
     set_cpu_mode(MODE_IRQ);
     reg[CPU_HALT_STATE] = CPU_ACTIVE;
     reg[CHANGED_PC_STATUS] = 1;

--- a/cpu.h
+++ b/cpu.h
@@ -90,7 +90,6 @@ typedef enum
 {
   TRANSLATION_REGION_RAM,
   TRANSLATION_REGION_ROM,
-  TRANSLATION_REGION_BIOS
 } translation_region_type;
 
 extern u32 instruction_count;
@@ -124,12 +123,10 @@ s32 translate_block_thumb(u32 pc, translation_region_type translation_region,
 #if defined(PSP)
   #define ROM_TRANSLATION_CACHE_SIZE (1024 * 512 * 4)
   #define RAM_TRANSLATION_CACHE_SIZE (1024 * 384)
-  #define BIOS_TRANSLATION_CACHE_SIZE (1024 * 128)
   #define TRANSLATION_CACHE_LIMIT_THRESHOLD (1024)
 #else
   #define ROM_TRANSLATION_CACHE_SIZE (1024 * 512 * 4 * 5)
   #define RAM_TRANSLATION_CACHE_SIZE (1024 * 384 * 2)
-  #define BIOS_TRANSLATION_CACHE_SIZE (1024 * 128 * 2)
   #define TRANSLATION_CACHE_LIMIT_THRESHOLD (1024 * 32)
 #endif
 
@@ -138,28 +135,22 @@ s32 translate_block_thumb(u32 pc, translation_region_type translation_region,
 #if defined(HAVE_MMAP)
 extern u8* rom_translation_cache;
 extern u8* ram_translation_cache;
-extern u8* bios_translation_cache;
 #elif defined(_3DS)
 #define rom_translation_cache ((u8*)0x02000000 - ROM_TRANSLATION_CACHE_SIZE)
 #define ram_translation_cache (rom_translation_cache - RAM_TRANSLATION_CACHE_SIZE)
-#define bios_translation_cache (ram_translation_cache - BIOS_TRANSLATION_CACHE_SIZE)
 extern u8* rom_translation_cache_ptr;
 extern u8* ram_translation_cache_ptr;
-extern u8* bios_translation_cache_ptr;
 #elif defined(VITA)
 extern u8* rom_translation_cache;
 extern u8* ram_translation_cache;
-extern u8* bios_translation_cache;
 extern int sceBlock;
 #else
 extern u8 rom_translation_cache[ROM_TRANSLATION_CACHE_SIZE];
 extern u8 ram_translation_cache[RAM_TRANSLATION_CACHE_SIZE];
-extern u8 bios_translation_cache[BIOS_TRANSLATION_CACHE_SIZE];
 extern u32 stub_arena[STUB_ARENA_SIZE];
 #endif
 extern u8 *rom_translation_ptr;
 extern u8 *ram_translation_ptr;
-extern u8 *bios_translation_ptr;
 
 #define MAX_TRANSLATION_GATES 8
 
@@ -182,7 +173,6 @@ extern u32 *rom_branch_hash[ROM_BRANCH_HASH_SIZE];
 
 void flush_translation_cache_rom(void);
 void flush_translation_cache_ram(void);
-void flush_translation_cache_bios(void);
 void dump_translation_cache(void);
 
 extern u32 reg_mode[7][7];

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -29,30 +29,23 @@
 
 u8 *last_rom_translation_ptr = NULL;
 u8 *last_ram_translation_ptr = NULL;
-u8 *last_bios_translation_ptr = NULL;
 
 #if defined(HAVE_MMAP)
 u8* rom_translation_cache;
 u8* ram_translation_cache;
-u8* bios_translation_cache;
 u8 *rom_translation_ptr;
 u8 *ram_translation_ptr;
-u8 *bios_translation_ptr;
 #elif defined(VITA)
 u8* rom_translation_cache;
 u8* ram_translation_cache;
-u8* bios_translation_cache;
 u8 *rom_translation_ptr;
 u8 *ram_translation_ptr;
-u8 *bios_translation_ptr;
 int sceBlock;
 #elif defined(_3DS) 
 u8* rom_translation_cache_ptr;
 u8* ram_translation_cache_ptr;
-u8* bios_translation_cache_ptr;
 u8 *rom_translation_ptr = rom_translation_cache;
 u8 *ram_translation_ptr = ram_translation_cache;
-u8 *bios_translation_ptr = bios_translation_cache;
 #else
 
 #ifdef __ANDROID__
@@ -71,10 +64,6 @@ u8 *rom_translation_ptr = rom_translation_cache;
 u8 ram_translation_cache[RAM_TRANSLATION_CACHE_SIZE]
 		__attribute__ ((aligned(4),section(".jit")));
 u8 *ram_translation_ptr = ram_translation_cache;
-
-u8 bios_translation_cache[BIOS_TRANSLATION_CACHE_SIZE]
-		__attribute__ ((aligned(4),section(".jit")));
-u8 *bios_translation_ptr = bios_translation_cache;
 
 __asm__(".section .text");
 #endif
@@ -276,10 +265,6 @@ void translate_icache_sync() {
     if (last_ram_translation_ptr < ram_translation_ptr) {
         platform_cache_sync(last_ram_translation_ptr, ram_translation_ptr);
         last_ram_translation_ptr = ram_translation_ptr;
-    }
-    if (last_bios_translation_ptr < bios_translation_ptr) {
-        platform_cache_sync(last_bios_translation_ptr, bios_translation_ptr);
-        last_bios_translation_ptr = bios_translation_ptr;
     }
 }
 
@@ -2703,9 +2688,6 @@ void translate_icache_sync() {
 u8 *ram_block_ptrs[1024 * 64];
 u32 ram_block_tag_top = 0x0101;
 
-u8 *bios_block_ptrs[1024 * 8];
-u32 bios_block_tag_top = 0x0101;
-
 // This function will return a pointer to a translated block of code. If it
 // doesn't exist it will translate it, if it does it will pass it back.
 
@@ -2735,7 +2717,6 @@ u32 bios_block_tag_top = 0x0101;
 
 #define ram_translation_region  TRANSLATION_REGION_RAM
 #define rom_translation_region  TRANSLATION_REGION_ROM
-#define bios_translation_region TRANSLATION_REGION_BIOS
 
 #define block_lookup_translate_arm(mem_type, smc_enable)                      \
   translation_result = translate_block_arm(pc, mem_type##_translation_region, \
@@ -2831,28 +2812,17 @@ u8 function_cc *block_lookup_address_##type(u32 pc)                           \
                                                                               \
   switch(pc >> 24)                                                            \
   {                                                                           \
-    case 0x0:                                                                 \
-      bios_region_read_allow();                                               \
-      location = (u16 *)(bios_rom + pc + 0x4000);                             \
-      block_lookup_translate(type, bios, 0);                                  \
-      if(translation_recursion_level == 0)                                    \
-        bios_region_read_allow();                                             \
-      break;                                                                  \
-                                                                              \
     case 0x2:                                                                 \
       location = (u16 *)(ewram + (pc & 0x7FFF) + ((pc & 0x38000) * 2));       \
       block_lookup_translate(type, ram, 1);                                   \
-      if(translation_recursion_level == 0)                                    \
-        bios_region_read_protect();                                           \
       break;                                                                  \
                                                                               \
     case 0x3:                                                                 \
       location = (u16 *)(iwram + (pc & 0x7FFF));                              \
       block_lookup_translate(type, ram, 1);                                   \
-      if(translation_recursion_level == 0)                                    \
-        bios_region_read_protect();                                           \
       break;                                                                  \
                                                                               \
+    case 0x0:                                                                 \
     case 0x8 ... 0xD:                                                         \
     {                                                                         \
       u32 hash_target = ((pc * 2654435761U) >> 16) &                          \
@@ -2876,7 +2846,7 @@ u8 function_cc *block_lookup_address_##type(u32 pc)                           \
                                                                               \
         redo:                                                                 \
                                                                               \
-        translation_recursion_level++;																				\
+        translation_recursion_level++;                                        \
         ((u32 *)rom_translation_ptr)[0] = pc;                                 \
         ((u32 **)rom_translation_ptr)[1] = NULL;                              \
         *block_ptr_address = (u32 *)rom_translation_ptr;                      \
@@ -2898,8 +2868,6 @@ u8 function_cc *block_lookup_address_##type(u32 pc)                           \
         if(translation_recursion_level == 0)                                  \
           translate_icache_sync();                                            \
       }                                                                       \
-      if(translation_recursion_level == 0)                                    \
-        bios_region_read_protect();                                           \
       break;                                                                  \
     }                                                                         \
                                                                               \
@@ -3310,12 +3278,6 @@ s32 translate_block_arm(u32 pc, translation_region_type
        rom_translation_cache + ROM_TRANSLATION_CACHE_SIZE -
        TRANSLATION_CACHE_LIMIT_THRESHOLD;
       break;
-
-    case TRANSLATION_REGION_BIOS:
-      translation_ptr = bios_translation_ptr;
-      translation_cache_limit = bios_translation_cache +
-       BIOS_TRANSLATION_CACHE_SIZE;
-      break;
   }
 
   generate_block_prologue();
@@ -3377,10 +3339,6 @@ s32 translate_block_arm(u32 pc, translation_region_type
 
         case TRANSLATION_REGION_ROM:
           flush_translation_cache_rom();
-          break;
-
-        case TRANSLATION_REGION_BIOS:
-          flush_translation_cache_bios();
           break;
       }
       return -1;
@@ -3448,10 +3406,6 @@ s32 translate_block_arm(u32 pc, translation_region_type
 
     case TRANSLATION_REGION_ROM:
       rom_translation_ptr = translation_ptr;
-      break;
-
-    case TRANSLATION_REGION_BIOS:
-      bios_translation_ptr = translation_ptr;
       break;
   }
 
@@ -3526,12 +3480,6 @@ s32 translate_block_thumb(u32 pc, translation_region_type
        rom_translation_cache + ROM_TRANSLATION_CACHE_SIZE -
        TRANSLATION_CACHE_LIMIT_THRESHOLD;
       break;
-
-    case TRANSLATION_REGION_BIOS:
-      translation_ptr = bios_translation_ptr;
-      translation_cache_limit = bios_translation_cache +
-       BIOS_TRANSLATION_CACHE_SIZE;
-      break;
   }
 
   generate_block_prologue();
@@ -3593,10 +3541,6 @@ s32 translate_block_thumb(u32 pc, translation_region_type
 
         case TRANSLATION_REGION_ROM:
           flush_translation_cache_rom();
-          break;
-
-        case TRANSLATION_REGION_BIOS:
-          flush_translation_cache_bios();
           break;
       }
       return -1;
@@ -3664,10 +3608,6 @@ s32 translate_block_thumb(u32 pc, translation_region_type
 
     case TRANSLATION_REGION_ROM:
       rom_translation_ptr = translation_ptr;
-      break;
-
-    case TRANSLATION_REGION_BIOS:
-      bios_translation_ptr = translation_ptr;
       break;
   }
 
@@ -3746,16 +3686,6 @@ void flush_translation_cache_rom(void)
   memset(rom_branch_hash, 0, sizeof(rom_branch_hash));
 }
 
-void flush_translation_cache_bios(void)
-{
-  bios_block_tag_top = 0x0101;
-
-  last_bios_translation_ptr = bios_translation_cache;
-  bios_translation_ptr = bios_translation_cache;
-
-  memset(bios_rom + 0x4000, 0, 0x4000);
-}
-
 #define cache_dump_prefix ""
 
 void dump_translation_cache(void)
@@ -3768,11 +3698,6 @@ void dump_translation_cache(void)
   fd = fopen(cache_dump_prefix "rom_cache.bin", "wb");
   fwrite(rom_translation_cache, 1,
    rom_translation_ptr - rom_translation_cache, fd);
-  fclose(fd);
-
-  fd = fopen(cache_dump_prefix "bios_cache.bin", "wb");
-  fwrite(bios_translation_cache, 1,
-   bios_translation_ptr - bios_translation_cache, fd);
   fclose(fd);
 }
 

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -310,8 +310,7 @@ u16 io_registers[1024 * 16];
 u8 ewram[1024 * 256 * 2];
 u8 iwram[1024 * 32 * 2];
 u8 vram[1024 * 96];
-
-u8 bios_rom[1024 * 16 * 2];
+u8 bios_rom[1024 * 16];
 u32 bios_read_protect;
 
 // Up to 128kb, store SRAM, flash ROM, or EEPROM here.
@@ -3373,17 +3372,6 @@ void memory_term(void)
   }
 }
 
-void bios_region_read_allow(void)
-{
-  memory_map_read[0] = bios_rom;
-}
-
-void bios_region_read_protect(void)
-{
-  memory_map_read[0] = NULL;
-}
-
-
 #define savestate_block(type)   \
   cpu_##type##_savestate();     \
   input_##type##_savestate();   \
@@ -3409,7 +3397,6 @@ void gba_load_state(const void* src)
    {
       flush_translation_cache_ram();
       flush_translation_cache_rom();
-      flush_translation_cache_bios();
    }
 #endif
 

--- a/gba_memory.h
+++ b/gba_memory.h
@@ -192,8 +192,6 @@ void update_backup(void);
 void init_memory(void);
 void init_gamepak_buffer(void);
 void memory_term(void);
-void bios_region_read_allow(void);
-void bios_region_read_protect(void);
 u8 *load_gamepak_page(u32 physical_index);
 
 extern u8 *gamepak_rom;
@@ -209,8 +207,8 @@ extern u16 oam_ram[512];
 extern u16 palette_ram_converted[512];
 extern u16 io_registers[1024 * 16];
 extern u8 vram[1024 * 96];
+extern u8 bios_rom[1024 * 16];
 // Double buffer used for SMC detection
-extern u8 bios_rom[1024 * 16 * 2];
 extern u8 ewram[1024 * 256 * 2];
 extern u8 iwram[1024 * 32 * 2];
 

--- a/main.c
+++ b/main.c
@@ -116,7 +116,6 @@ void init_main(void)
 #ifdef HAVE_DYNAREC
   flush_translation_cache_rom();
   flush_translation_cache_ram();
-  flush_translation_cache_bios();
   init_emitter();
 #endif
 }


### PR DESCRIPTION
This is not really necessary since it can share area with ROM.
Performance impact should be very minimal (haven't noticed it myself)
and could be compensated (even by a positive offset) if we bump the ROM
cache area size.
Tested with several dynarecs.