### PR TITLE
Enable runtime dynarec enable/disable

### DIFF
--- a/common.h
+++ b/common.h
@@ -31,6 +31,7 @@
   #define PATH_SEPARATOR_CHAR '/'
 #endif
 
+/* On x86 we pass arguments via registers instead of stack */
 #ifdef X86_ARCH
   #define function_cc __attribute__((regparm(2)))
 #else
@@ -55,8 +56,6 @@
 // functions on PSP for vastly improved memstick performance.
 
 #ifdef PSP
-  #define fastcall
-
   #include <pspkernel.h>
   #include <pspdebug.h>
   #include <pspctrl.h>
@@ -64,13 +63,8 @@
   #include <pspaudio.h>
   #include <pspaudiolib.h>
   #include <psprtc.h>
-
-  #define convert_palette(value)  \
-    value = ((value & 0x7FE0) << 1) | (value & 0x1F)
-
   #include <time.h>
 #else
-
   typedef unsigned char u8;
   typedef signed char s8;
   typedef unsigned short int u16;
@@ -79,10 +73,14 @@
   typedef signed int s32;
   typedef unsigned long long int u64;
   typedef signed long long int s64;
+#endif
 
+#ifdef USE_BGR_FORMAT
+  #define convert_palette(value)  \
+    value = ((value & 0x7FE0) << 1) | (value & 0x1F)
+#else
   #define convert_palette(value) \
     value = ((value & 0x1F) << 11) | ((value & 0x03E0) << 1) | (value >> 10)
-
 #endif
 
 #define GBA_SCREEN_WIDTH  (240)

--- a/cpu.h
+++ b/cpu.h
@@ -174,6 +174,7 @@ extern u32 *rom_branch_hash[ROM_BRANCH_HASH_SIZE];
 void flush_translation_cache_rom(void);
 void flush_translation_cache_ram(void);
 void dump_translation_cache(void);
+void wipe_caches(void);
 
 extern u32 reg_mode[7][7];
 extern u32 spsr[6];

--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -3686,6 +3686,17 @@ void flush_translation_cache_rom(void)
   memset(rom_branch_hash, 0, sizeof(rom_branch_hash));
 }
 
+void wipe_caches(void)
+{
+  /* Ensure we wipe everything including the SMC mirrors */
+  flush_translation_cache_rom();
+  ewram_code_min = 0;
+  ewram_code_max = 0x3FFFF;
+  iwram_code_min = 0;
+  iwram_code_max = 0x7FFF;
+  flush_translation_cache_ram();
+}
+
 #define cache_dump_prefix ""
 
 void dump_translation_cache(void)

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -3394,10 +3394,7 @@ void gba_load_state(const void* src)
 
 #ifdef HAVE_DYNAREC
    if (dynarec_enable)
-   {
-      flush_translation_cache_ram();
-      flush_translation_cache_rom();
-   }
+      wipe_caches();
 #endif
 
    oam_update = 1;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -147,7 +147,7 @@ struct retro_core_option_definition option_defs_us[] = {
 #if defined(HAVE_DYNAREC)
    {
       "gpsp_drc",
-      "Dynamic Recompiler (Restart)",
+      "Dynamic Recompiler",
       "Dynamically recompile CPU instructions to native instructions. Greatly improves performance, but may reduce accuracy.",
       {
          { "enabled",  NULL },

--- a/main.c
+++ b/main.c
@@ -114,8 +114,7 @@ void init_main(void)
   video_count = 960;
 
 #ifdef HAVE_DYNAREC
-  flush_translation_cache_rom();
-  flush_translation_cache_ram();
+  wipe_caches();
   init_emitter();
 #endif
 }

--- a/x86/x86_stub.S
+++ b/x86/x86_stub.S
@@ -538,7 +538,7 @@ _execute_arm_translate:
 
   # (if the CPU is halted, do not start executing but
   #  loop in the alert loop until it wakes up)
-  cmp $0, CPU_HALT_STATE(%ebx)
+  cmpl $0, CPU_HALT_STATE(%ebx)
   je 1f
   call alert_loop     # Need to push something to the stack
   


### PR DESCRIPTION
Added a more thorough cache cleanup for reset/mode-change too.
Fixed the mmap initialization that ends up leaking memory.
Minor x86 asm fixes for Android.