### PR TITLE
Fix aligned32 reads in interpreter mode

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -1024,7 +1024,7 @@ const u32 psr_masks[16] =
     memory_region_access_read_u32[_address >> 24]++;                          \
     memory_reads_u32++;                                                       \
   }                                                                           \
-  if(map)                                                                     \
+  if(_address < 0x10000000 && map)                                            \
   {                                                                           \
     dest = address32(map, _address & 0x7FFF);                                 \
   }                                                                           \


### PR DESCRIPTION
An address check was missing to read aligned 32 (stm/ldm) data from
high mem areas (0xX0000000). This fixes SM4 EU that for some reason has
some weird memory access (perhaps a bug?)