### PR TITLE
RS90 Support - Testing Only (No Dynarec)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,18 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING = 1
 
+# RS90 (OD and OD Beta)
+else ifeq ($(platform), rs90)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+	CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+	AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+	SHARED := -shared -nostdlib -Wl,--version-script=link.T
+	fpic := -fPIC -DPIC
+	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32
+	HAVE_DYNAREC := 1
+	CPU_ARCH := mips
+
 # GCW0 (OD and OD Beta)
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ else ifeq ($(platform), rs90)
 	SHARED := -shared -nostdlib -Wl,--version-script=link.T
 	fpic := -fPIC -DPIC
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32
-	HAVE_DYNAREC := 1
+	HAVE_DYNAREC := 0
 	CPU_ARCH := mips
 
 # GCW0 (OD and OD Beta)


### PR DESCRIPTION
## Update

This should be ready to merge for now. Trying to enable dynarec on this platform causes the core to hang and crash. I imagine there's a rather large amount of memory allocation that needs to take place for the recompiler to work?

Runs at less than 1/2 speed without dynarec, but it might make sense to merge this in so other people can test.


## Old post

~Don't merge this yet.~

~This *should* work on the RS90, but when you run it, the core immediately crashes.~

~I think there's some subtle bug with the MIPS32 dyanrec if you *don't* have the `CFLAGS += -DMIPS_HAS_R2_INSTS` flag.~

~Going to build it with the same flags, but for the RG350 and see if it exhibits the same behavior. If it doesn't, then it's likely due to the RS90's limited RAM.~