### PR TITLE
platforms/miyoo: Use small translation cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,7 @@ else ifeq ($(platform), miyoo)
 	SHARED := -shared -nostdlib -Wl,--version-script=link.T
 	fpic := -fPIC -DPIC
 	CFLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
+	CFLAGS += -DSMALL_TRANSLATION_CACHE
 	HAVE_DYNAREC := 1
 	CPU_ARCH := arm
 


### PR DESCRIPTION
As this platform only has 32MB RAM.