### PR TITLE
Pokemon Fire Red germany not booting/ White Screen

### DIFF
--- a/gba_over.h
+++ b/gba_over.h
@@ -1532,7 +1532,7 @@ static const ini_t gbaover[] = {
    {
       // Pokemon: Fire Red (G)
       "POKEMON FIRE",              /* gamepak_title        */
-      "BPRG",                      /* gamepak_code         */
+      "BPRD",                      /* gamepak_code         */
       "01",                        /* gamepak_maker        */
       0,                           /* flash_size           */
       FLASH_DEVICE_MACRONIX_128KB, /* flash_device_id      */


### PR DESCRIPTION
Wrong Gamepak Code causing Pokemon Fire Red not to boot due to wrong flash size (64k instead of 128k)
German version of Pokemon Leaf works beautifully...
In "game_config.txt" the gamepak code is correct. However, Firered German Version still will not boot.

![firered](https://user-images.githubusercontent.com/63744307/169522447-690dd494-9c00-40cd-a085-6bc0ee42750b.PNG)

Changing Header of the Rom to wrong (and not official) Gamepak "BPRG", the Game will boot.

![firered2](https://user-images.githubusercontent.com/63744307/169523498-fbb319c1-fc91-4a9d-845b-86de6f63bf2b.PNG)

I think the "game_config.txt" will not be used and the settings are hardcoded to the build, correct?

Please pull the change.

Thanks!
