### PR TITLE
[ARM32] Fix for Kingdom Hearts Chain of Memories

### DIFF
--- a/arm/arm_emit.h
+++ b/arm/arm_emit.h
@@ -1374,7 +1374,11 @@ static void trace_instruction(u32 pc, u32 mode)
   cycle_count += 2;                                                           \
   generate_load_call_##mem_type();                                            \
   write32(pc);                                                                \
-  arm_generate_store_reg_pc_no_flags(reg_rv, rd)                              \
+  arm_generate_store_reg_pc_no_flags(reg_rv, rd);                             \
+  if(rd == REG_PC)                                                            \
+  {                                                                           \
+    generate_indirect_branch_arm();                                           \
+  }
 
 #define arm_access_memory_store(mem_type)                                     \
   cycle_count++;                                                              \


### PR DESCRIPTION
Kingdom Hearts crashes on the intro seemingly on all versions - have traced this back to gpsp 0.8, where it was working.  Adding an ARM equivalent of the MIPS check_store_reg_pc_no_flags(rd) in the arm_access_memory_load function appears to fix it on my platform (no crash on the intro after adding this line and building)?  @davidgfnet can you test and confirm?