### PR TITLE
[ARM32] Block Memory timing tweak (fixes Kingdom Hearts)

### DIFF
--- a/arm/arm_emit.h
+++ b/arm/arm_emit.h
@@ -1546,12 +1546,11 @@ static void trace_instruction(u32 pc, u32 mode)
   arm_block_memory_writeback_##access_type(writeback_type);                   \
   ARM_BIC_REG_IMM(0, reg_s0, reg_s0, 0x03, 0);                                \
   arm_generate_store_reg(reg_s0, REG_SAVE);                                   \
-                                                                              \
+  cycle_count++;                                                              \
   for(i = 0; i < 16; i++)                                                     \
   {                                                                           \
     if((reg_list >> i) & 0x01)                                                \
-    {                                                                         \
-      cycle_count++;                                                          \
+    {                                                                         \                                                         
       arm_generate_load_reg(reg_s0, REG_SAVE);                                \
       generate_add_reg_reg_imm(reg_a0, reg_s0, offset, 0);                    \
       if(reg_list & ~((2 << i) - 1))                                          \
@@ -1865,12 +1864,11 @@ static void trace_instruction(u32 pc, u32 mode)
   thumb_block_address_preadjust_##pre_op();                                   \
   thumb_block_address_postadjust_##post_op(base_reg);                         \
   thumb_generate_store_reg(reg_s0, REG_SAVE);                                 \
-                                                                              \
+  cycle_count++;                                                              \                                                                              
   for(i = 0; i < 8; i++)                                                      \
   {                                                                           \
     if((reg_list >> i) & 0x01)                                                \
     {                                                                         \
-      cycle_count++;                                                          \
       thumb_generate_load_reg(reg_s0, REG_SAVE);                              \
       generate_add_reg_reg_imm(reg_a0, reg_s0, offset, 0);                    \
       if(reg_list & ~((2 << i) - 1))                                          \


### PR DESCRIPTION
Moving the cycle_count increment out of the loop and just making it a single increment for these operations fixes the crash in the video at the beginning of Kingdom Hearts described in issue #183 .  This crash is intermittent - it will usually happen when starting the game 'cold' (i.e. first game after loading up RetroArch), and happens about 4-6 times out of 10 starts of the game.  

This tweak to timing results in 10 successful starts of the game with no crash.

NOW - I don't know if this will have a negative effect on other games.  Anecdotally other games I've tried seem to work ok, but I guess a run with Miniretro would probably be the proof.  I made this change after reading some of Exophase's old notes on how timing tweaks are necessary to fix some games (Mario and Luigi SS Saga is another case in point).