### PR TITLE
Fix right bit-shift typo in update timers function

### DIFF
--- a/main.c
+++ b/main.c
@@ -51,7 +51,7 @@ static unsigned update_timers(irq_type *irq_raised, unsigned completed_cycles)
       {
          timer[i].count -= completed_cycles;
          /* io_registers accessors range: REG_TM0D, REG_TM1D, REG_TM2D, REG_TM3D */
-         write_ioreg(REG_TM0D + (i * 2), -(timer[i].count > timer[i].prescale));
+         write_ioreg(REG_TM0D + (i * 2), -(timer[i].count >> timer[i].prescale));
       }
 
       if(timer[i].count > 0)


### PR DESCRIPTION
This typo originates from commit 0bc2a11 all the way back in 2014, when the function was de-macroized and partially rewritten.  

It seemingly fixes several games which would hang on startup, such as Smashing Drive, Wolfenstein 3d, Street Racing Syndicate and also  Final Fantasy V Advance Russian Translation (issue #170).  Although Street Racing Syndicate now seems to have a separate issue with ARM32 Dynarec as it crashes after hitting the start button (Interpreter works ok).