### PR TITLE
Fix Missing Sound on GBC Channel 4

### DIFF
--- a/sound.c
+++ b/sound.c
@@ -345,12 +345,12 @@ u32 gbc_sound_master_volume;
 #define get_noise_sample_full()                                               \
   current_sample =                                                            \
    ((s32)(noise_table15[fp16_16_to_u32(sample_index) >> 5] <<                 \
-   (fp16_16_to_u32(sample_index) & 0x1F)) >> 31) & 0x0F                       \
+   (fp16_16_to_u32(sample_index) & 0x1F)) >> 31) ^ 0x07                       \
 
 #define get_noise_sample_half()                                               \
   current_sample =                                                            \
    ((s32)(noise_table7[fp16_16_to_u32(sample_index) >> 5] <<                  \
-   (fp16_16_to_u32(sample_index) & 0x1F)) >> 31) & 0x0F                       \
+   (fp16_16_to_u32(sample_index) & 0x1F)) >> 31) ^ 0x07                       \
 
 #define gbc_sound_render_noise(type, noise_type, envelope_op, sweep_op)       \
   for(i = 0; i < buffer_ticks; i++)                                           \


### PR DESCRIPTION
A user on RGH Discord group pointed out that certain sound effects were missing. (Sonic Advance was used as an example, when jumping on a box or enemy). After investigating with the user, we found that it was specifically noise sound effects on GBC Sound Channel 4 that were missing.

I tested the ROM on TempGBA and found the sound was correctly emulated. I have therefore implemented the differences for noise sample handling from TempGBA to this fork of gpsp in this PR. I have tested Sonic Advance and it fixes the issue (i.e. a proper 'crunch' sound is now played when jumping on a box, which is correct behaviour).

The previous PR I created for this made more changes than necessary - as it turns out, just the changes in this PR are needed to fix the issue.