### PR TITLE
Banjo Kazooie GR - Intro black screen fix

### DIFF
--- a/video.c
+++ b/video.c
@@ -32,8 +32,11 @@ static void render_scanline_conditional_bitmap(u32 start, u32 end, u16 *scanline
  *layer_renderers);
 
 #define tile_expand_base_normal(index)                                        \
-  current_pixel = palette[current_pixel];                                     \
-  dest_ptr[index] = current_pixel                                             \
+  if (current_pixel != 0)                                                     \
+  {                                                                           \
+    tile_lookup_palette(palette, current_pixel);                              \
+    dest_ptr[index] = current_pixel;                                          \
+  }                                                                           \
 
 #define tile_expand_transparent_normal(index)                                 \
   tile_expand_base_normal(index)                                              \


### PR DESCRIPTION
This fixes the black screen on the intro for Banjo Kazooie.  Fix is taken from gpsp Kai.  In gpsp Kai this is a separate function used only by bitmap_render_pixel_mode4, so it may need to be here as well, but testing the combined function so far with other games doesn't appear to cause any issues.