### PR TITLE
Proposed changes to partially fix transparency

### DIFF
--- a/video.c
+++ b/video.c
@@ -3158,11 +3158,7 @@ static u32 obj_alpha_count[160];
 #define render_scanline_obj_extra_variables_alpha_obj(map_space)              \
   render_scanline_obj_extra_variables_color();                                \
   u32 dest;                                                                   \
-  if((pixel_combine & 0x00000200) == 0)                                       \
-  {                                                                           \
-    render_scanline_obj_color32_##map_space(priority, start, end, scanline);  \
-    return;                                                                   \
-  }                                                                           \
+  u32 base_pixel_combine = pixel_combine;                                     \
 
 #define render_scanline_obj_extra_variables_color16(map_space)                \
   render_scanline_obj_extra_variables_color()                                 \
@@ -3335,8 +3331,8 @@ render_scanline_obj_builder(transparent, color16, 1D, no_partial_alpha);
 render_scanline_obj_builder(transparent, color16, 2D, no_partial_alpha);
 render_scanline_obj_builder(transparent, color32, 1D, no_partial_alpha);
 render_scanline_obj_builder(transparent, color32, 2D, no_partial_alpha);
-render_scanline_obj_builder(transparent, alpha_obj, 1D, no_partial_alpha);
-render_scanline_obj_builder(transparent, alpha_obj, 2D, no_partial_alpha);
+render_scanline_obj_builder(transparent, alpha_obj, 1D, partial_alpha);
+render_scanline_obj_builder(transparent, alpha_obj, 2D, partial_alpha);
 render_scanline_obj_builder(transparent, partial_alpha, 1D, partial_alpha);
 render_scanline_obj_builder(transparent, partial_alpha, 2D, partial_alpha);
 render_scanline_obj_builder(copy, copy_tile, 1D, no_partial_alpha);
@@ -4510,5 +4506,4 @@ void update_scanline(void)
   affine_reference_x[1] += (s16)read_ioreg(REG_BG3PB);
   affine_reference_y[1] += (s16)read_ioreg(REG_BG3PD);
 }
-
 


### PR DESCRIPTION
Remove the 1st Target check which can incorrectly renders ST OBJs with no transparency.

Change alpha_objs to use the partial alpha code path.

These changes seemingly fix the transparency on table selection in Pokemon Pinball (the second table is black otherwise until selected, rather than darkened) and also partially fix the black boxes in Golden Sun, but more understanding is required here before committing to main branch, as other problems such as the Slot in Pokemon Pinball and the OBJ transparency in Payback still persist.