### PR TITLE
Don't update background scanline params in mode 0

### DIFF
--- a/video.c
+++ b/video.c
@@ -4527,11 +4527,14 @@ void update_scanline(void)
         render_scanline_bitmap(screen_offset, dispcnt);
     }
   }
-
-  affine_reference_x[0] += (s16)read_ioreg(REG_BG2PB);
-  affine_reference_y[0] += (s16)read_ioreg(REG_BG2PD);
-  affine_reference_x[1] += (s16)read_ioreg(REG_BG3PB);
-  affine_reference_y[1] += (s16)read_ioreg(REG_BG3PD);
+  // Don't update background scanline params in mode 0
+  if(video_mode != 0)
+  {
+    affine_reference_x[0] += (s16)read_ioreg(REG_BG2PB);
+    affine_reference_y[0] += (s16)read_ioreg(REG_BG2PD);
+    affine_reference_x[1] += (s16)read_ioreg(REG_BG3PB);
+    affine_reference_y[1] += (s16)read_ioreg(REG_BG3PD);
+  }
 }
 
 


### PR DESCRIPTION
Noticed that an issue with Rayman 3 Hoodlum Havoc was reported on one of the gpsp compatability lists.  Cross-checked against mgba and revealed the same issue reported as being present in an earlier version -

https://github.com/mgba-emu/mgba/issues/377

This PR applies the same fix as used in mgba.  Could affect other games also.