### PR TITLE
Add u1 extension to supported filetypes

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -488,7 +488,7 @@ void retro_get_system_info(struct retro_system_info* info)
    info->library_version = "v0.91" GIT_VERSION;
    info->need_fullpath = true;
    info->block_extract = false;
-   info->valid_extensions = "gba|bin|agb|gbz" ;
+   info->valid_extensions = "gba|bin|agb|gbz|u1" ;
 }
 
 


### PR DESCRIPTION
As requested in issue #37 .  Could probably lose the 'v0.91' from the build version as well and just have it report the github build.