### PR TITLE
Fix save_type in game overrides (gba_over.h / game_config.txt)

### DIFF
--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1745,16 +1745,20 @@ static s32 load_game_config_over(gamepak_info_t *gpinfo)
         translation_gate_targets++;
      }
 
-     save_type     = gbaover[i].save_type;
-     if (save_type == sram)
+     u8 save_type     = gbaover[i].save_type;
+     if (save_type == 1)
         backup_type = BACKUP_SRAM;
-     if (save_type == eeprom)
+     if (save_type == 2)
         backup_type = BACKUP_EEPROM;
-     if (save_type == flash)
+        eeprom_size = EEPROM_512_BYTE;
+     if (save_type == 3)
         backup_type = BACKUP_FLASH;
+     if (save_type == 4)
+        backup_type = BACKUP_EEPROM;
+        eeprom_size = EEPROM_8_KBYTE;
     
      printf("found entry in over ini file.\n");
-     printf("save type set to : %d\n", backup_type);
+     printf("(1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K - Save type set to : %d\n", save_type);
 
      return 0;
   }
@@ -2528,7 +2532,7 @@ void init_memory(void)
 
   flash_bank_num = 0;
   flash_command_position = 0;
-  eeprom_size = EEPROM_512_BYTE;
+  // eeprom_size = EEPROM_512_BYTE;
   eeprom_mode = EEPROM_BASE_MODE;
   eeprom_address = 0;
   eeprom_counter = 0;

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1745,11 +1745,21 @@ static s32 load_game_config_over(gamepak_info_t *gpinfo)
         translation_gate_targets++;
      }
 
+     save_type     = gbaover[i].save_type;
+     if (save_type == sram)
+        backup_type = BACKUP_SRAM;
+     if (save_type == eeprom)
+        backup_type = BACKUP_EEPROM;
+     if (save_type == flash)
+        backup_type = BACKUP_FLASH;
+    
      printf("found entry in over ini file.\n");
+     printf("save type set to : %d\n", backup_type);
 
      return 0;
   }
 
+  backup_type = BACKUP_NONE;
   return -1;
 }
 
@@ -1764,6 +1774,10 @@ static s32 load_game_config(gamepak_info_t *gpinfo)
   sprintf(config_path, "%s" PATH_SEPARATOR "%s", main_path, CONFIG_FILENAME);
 
   printf("config_path is : %s\n", config_path);
+  
+  printf("game name is : %s\n", gpinfo->gamepak_title);
+  printf("game code is : %s\n", gpinfo->gamepak_code);
+  printf("vendor code is : %s\n", gpinfo->gamepak_maker);
 
   config_file = filestream_open(config_path, RETRO_VFS_FILE_ACCESS_READ,
                                 RETRO_VFS_FILE_ACCESS_HINT_NONE);
@@ -1820,6 +1834,21 @@ static s32 load_game_config(gamepak_info_t *gpinfo)
             if(!strcmp(current_variable, "flash_rom_type") &&
               !strcmp(current_value, "128KB"))
               flash_device_id = FLASH_DEVICE_MACRONIX_128KB;
+
+            if(!strcmp(current_variable, "save_type") &&
+                    !strcmp(current_value, "sram"))
+                    backup_type = BACKUP_SRAM;
+      
+            if(!strcmp(current_variable, "save_type") &&
+                    !strcmp(current_value, "eeprom"))
+                    backup_type = BACKUP_EEPROM;
+       
+            if(!strcmp(current_variable, "save_type") &&
+                    !strcmp(current_value, "flash"))
+                    backup_type = BACKUP_FLASH;
+      
+            printf("save type set to : %d\n", backup_type);
+
           }
         }
 
@@ -1832,6 +1861,7 @@ static s32 load_game_config(gamepak_info_t *gpinfo)
   }
 
   printf("game config missing\n");
+  backup_type = BACKUP_NONE;
   return -1;
 }
 
@@ -2491,7 +2521,7 @@ void init_memory(void)
 
   reload_timing_info();
 
-  backup_type = BACKUP_NONE;
+  // backup_type = BACKUP_NONE;
 
   sram_bankcount = SRAM_SIZE_32KB;
   //flash_size = FLASH_SIZE_64KB;
@@ -2745,5 +2775,4 @@ s32 load_bios(char *name)
   filestream_close(fd);
   return 0;
 }
-
 

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1762,7 +1762,7 @@ static s32 load_game_config_over(gamepak_info_t *gpinfo)
         backup_type = BACKUP_DISABLED;
     
      printf("found entry in over ini file.\n");
-     printf("(0=NO OVERRIDE, 1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K - Save type set to : %d\n", save_type);
+     printf("(0=NO OVERRIDE, 1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K, 5=BACKUP DISABLED - Save type set to : %d\n", save_type);
 
      return 0;
   }

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1006,11 +1006,13 @@ cpu_alert_type function_cc write_io_register32(u32 address, u32 value)
 
 void function_cc write_backup(u32 address, u32 value)
 {
-  value &= 0xFF;
+  if(backup_type == BACKUP_DISABLED)
+    return;
 
+  value &= 0xFF;
+  
   if(backup_type == BACKUP_NONE)
     backup_type = BACKUP_SRAM;
-
 
   // gamepak SRAM or Flash ROM
   if((address == 0x5555) && (flash_mode != FLASH_WRITE_MODE))
@@ -1756,6 +1758,8 @@ static s32 load_game_config_over(gamepak_info_t *gpinfo)
      if (save_type == 4)
         backup_type = BACKUP_EEPROM;
         eeprom_size = EEPROM_8_KBYTE;
+    if (save_type == 5)
+        backup_type = BACKUP_DISABLED;
     
      printf("found entry in over ini file.\n");
      printf("(0=NO OVERRIDE, 1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K - Save type set to : %d\n", save_type);

--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1758,7 +1758,7 @@ static s32 load_game_config_over(gamepak_info_t *gpinfo)
         eeprom_size = EEPROM_8_KBYTE;
     
      printf("found entry in over ini file.\n");
-     printf("(1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K - Save type set to : %d\n", save_type);
+     printf("(0=NO OVERRIDE, 1=SRAM, 2=EEPROM_1K, 3=FLASH, 4=EEPROM_8K - Save type set to : %d\n", save_type);
 
      return 0;
   }
@@ -1844,14 +1844,20 @@ static s32 load_game_config(gamepak_info_t *gpinfo)
                     backup_type = BACKUP_SRAM;
       
             if(!strcmp(current_variable, "save_type") &&
-                    !strcmp(current_value, "eeprom"))
+                    !strcmp(current_value, "eeprom1k"))
                     backup_type = BACKUP_EEPROM;
+                    eeprom_size = EEPROM_512_BYTE;
+
+            if(!strcmp(current_variable, "save_type") &&
+                    !strcmp(current_value, "eeprom8k"))
+                    backup_type = BACKUP_EEPROM;
+                    eeprom_size = EEPROM_8_KBYTE;
        
             if(!strcmp(current_variable, "save_type") &&
                     !strcmp(current_value, "flash"))
                     backup_type = BACKUP_FLASH;
       
-            printf("save type set to : %d\n", backup_type);
+            printf("0=NO OVERRIDE, 1=SRAM, 2=EEPROM, 3=FLASH - Save type set to : %d\n", backup_type);
 
           }
         }

--- a/gba_memory.h
+++ b/gba_memory.h
@@ -248,6 +248,7 @@ extern u32 reg[64];
 #define BACKUP_FLASH      1
 #define BACKUP_EEPROM     2
 #define BACKUP_NONE       3
+#define BACKUP_DISABLED   4
 
 #define SRAM_SIZE_32KB    1
 #define SRAM_SIZE_64KB    2

--- a/gba_over.h
+++ b/gba_over.h
@@ -364,6 +364,20 @@ static const ini_t gbaover[] = {
       0,                           /* translation_gate_target_3 */
    },
    {
+      // Dragon Ball Z - The Legacy of Goku II (USA)
+      "DBZLGCYGOKU2",               /* gamepak_title        */
+      "ALFE",                      /* gamepak_code         */
+      "70",                        /* gamepak_maker        */
+      0,                           /* flash_size           */
+      FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
+      3,                           /* save_type            */
+      0,                           /* rtc_enabled          */
+      0,                           /* idle_loop_target_pc  */
+      0,                           /* translation_gate_target_1 */
+      0,                           /* translation_gate_target_2 */
+      0,                           /* translation_gate_target_3 */
+   },
+   {
       // Drill Dozer (U)
       "DRILL DOZER",               /* gamepak_title        */
       "V49E",                      /* gamepak_code         */
@@ -2261,6 +2275,20 @@ static const ini_t gbaover[] = {
       0,                           /* save_type            */
       0,                           /* rtc_enabled          */
       0x8000f66,                   /* idle_loop_target_pc  */
+      0,                           /* translation_gate_target_1 */
+      0,                           /* translation_gate_target_2 */
+      0,                           /* translation_gate_target_3 */
+   },
+   {
+      // Yggdra Union - We'll Never Fight Alone (U)
+      "YGGDRA UNION",              /* gamepak_title        */
+      "BYUE",                      /* gamepak_code         */
+      "EB",                        /* gamepak_maker        */
+      0,                           /* flash_size           */
+      FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
+      3,                           /* save_type            */
+      0,                           /* rtc_enabled          */
+      0,                           /* idle_loop_target_pc  */
       0,                           /* translation_gate_target_1 */
       0,                           /* translation_gate_target_2 */
       0,                           /* translation_gate_target_3 */

--- a/gba_over.h
+++ b/gba_over.h
@@ -2210,6 +2210,20 @@ static const ini_t gbaover[] = {
       0,                           /* translation_gate_target_3 */
    },
    {
+      // Top Gun - Combat Zones (USA)
+      "TOPGUN CZ",                 /* gamepak_title        */
+      "A2YE",                      /* gamepak_code         */
+      "60",                        /* gamepak_maker        */
+      0,                           /* flash_size           */
+      FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
+      5,                           /* save_type            */
+      0,                           /* rtc_enabled          */
+      0,                           /* idle_loop_target_pc  */
+      0,                           /* translation_gate_target_1 */
+      0,                           /* translation_gate_target_2 */
+      0,                           /* translation_gate_target_3 */
+   },
+   {
       // Tottoko Hamutaro Hamuhamu Sports (J/U)
       "HAMSPORTS",                 /* gamepak_title        */
       "B85A",                      /* gamepak_code         */
@@ -2244,7 +2258,7 @@ static const ini_t gbaover[] = {
       "D9",                        /* gamepak_maker        */
       0,                           /* flash_size           */
       FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
-      0,                           /* save_type            */
+      4,                           /* save_type            */
       0,                           /* rtc_enabled          */
       0,                           /* idle_loop_target_pc  */
       0,                           /* translation_gate_target_1 */

--- a/gba_over.h
+++ b/gba_over.h
@@ -370,7 +370,21 @@ static const ini_t gbaover[] = {
       "70",                        /* gamepak_maker        */
       0,                           /* flash_size           */
       FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
-      3,                           /* save_type            */
+      4,                           /* save_type            */
+      0,                           /* rtc_enabled          */
+      0,                           /* idle_loop_target_pc  */
+      0,                           /* translation_gate_target_1 */
+      0,                           /* translation_gate_target_2 */
+      0,                           /* translation_gate_target_3 */
+   },
+   {
+      // Dragon Ball Z - Taiketsu (USA)
+      "DBZ TAIKETSU",               /* gamepak_title        */
+      "BDBE",                      /* gamepak_code         */
+      "70",                        /* gamepak_maker        */
+      0,                           /* flash_size           */
+      FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
+      4,                           /* save_type            */
       0,                           /* rtc_enabled          */
       0,                           /* idle_loop_target_pc  */
       0,                           /* translation_gate_target_1 */
@@ -2286,7 +2300,7 @@ static const ini_t gbaover[] = {
       "EB",                        /* gamepak_maker        */
       0,                           /* flash_size           */
       FLASH_DEVICE_UNDEFINED,      /* flash_device_id      */
-      3,                           /* save_type            */
+      4,                           /* save_type            */
       0,                           /* rtc_enabled          */
       0,                           /* idle_loop_target_pc  */
       0,                           /* translation_gate_target_1 */

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1122,6 +1122,9 @@ size_t retro_get_memory_size(unsigned id)
 
          case BACKUP_EEPROM:
             return 0x200 * eeprom_size;
+           
+         case BACKUP_DISABLED:
+            return 0;
 
          // assume 128KB save, regardless if rom supports battery saves
          // this is needed because gba cannot provide initially the backup save size 


### PR DESCRIPTION
The 'save_type' field in gba_over.h / game_config.txt doesn't currently work, due to no code being in place to process the field.

It should provide an override in the case where the backup method (e.g. Flash, SRAM or EEPROM) is incorrectly detected by gpsp and thus prevents the game from being able to save (mgba has similar functionality). This also causes the copy protection to trigger in some games, such as the Dragon Ball series.

This PR adds code to process save_type values against games in gba_over.h.

save_type can now have 6 possible values - no override, flash, sram, eeprom(1k), eeprom(8k) or backup disabled .  gpsp should do the rest in determining the necessary size for the sram and flash values.  The backup disabled option is required for games like Top Gun Combat Zone, which don't use saving, and employ copy protection based on if the game detects any flash/sram/eeprom at all.

Have also added a few game entries to gba_over.h which were used in testing.