### PR TITLE
Update gba_over.h

### DIFF
--- a/gba_over.h
+++ b/gba_over.h
@@ -1560,7 +1560,7 @@ static const ini_t gbaover[] = {
       "POKE DUNGEON",              /* gamepak_title        */
       "B24J",                      /* gamepak_code         */
       "01",                        /* gamepak_maker        */
-      FLAGS_FLASH_128KB,           /* flags                */
+      0,                           /* flags                */
       0,                           /* idle_loop_target_pc  */
       0,                           /* translation_gate_target_1 */
       0,                           /* translation_gate_target_2 */


### PR DESCRIPTION
The game Pokemon Fushigi no Dungeon - Aka no Kyuujotai (Japan) (AGB-B24J-JPN) requires the Flash 512kb save type.
By default, gpSP uses the Flash 1Mb save type for it, resulting in not being able to save.
[https://github.com/libretro/gpsp/issues/239](https://github.com/libretro/gpsp/issues/239)