### PR TITLE
Remove execute_cycles adjustment based on video_count value

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-/* gameplaySP
+  1/* gameplaySP
  *
  * Copyright (C) 2006 Exophase <exophase@gmail.com>
  *
@@ -262,7 +262,7 @@ u32 function_cc update_gba(int remaining_cycles)
 
     // Figure out when we need to stop CPU execution. The next event is
     // a video event or a timer event, whatever happens first.
-    execute_cycles = MAX(video_count, 0);
+    // execute_cycles = MAX(video_count, 0);
     {
       u32 cc = serial_next_event();
       execute_cycles = MIN(execute_cycles, cc);


### PR DESCRIPTION
Commenting out this line appears to fix issue #224 with no adverse effects elsewhere, as far as I can see through limited testing on these games and other games in my collection.

@davidgfnet you will know far better than me, but maybe this line is rendered unnecessary following after you implemented DMA sleep mode and taking into account those cycles?