### PR TITLE
Partially revert 8036ad5 to restore audio loss described in issue #242

### DIFF
--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -2997,7 +2997,6 @@ block_exit_type block_exits[MAX_EXITS];
   pc &= ~0x01                                                                 \
 
 #define update_pc_limits()                                                    \
-if (ram_region) {                                                             \
   if (pc >= 0x3000000) {                                                      \
     iwram_code_min = MIN(pc & 0x7FFF, iwram_code_min);                        \
     iwram_code_max = MAX(pc & 0x7FFF, iwram_code_max);                        \
@@ -3005,7 +3004,7 @@ if (ram_region) {                                                             \
     ewram_code_min = MIN(pc & 0x3FFFF, ewram_code_min);                       \
     ewram_code_max = MAX(pc & 0x3FFFF, ewram_code_max);                       \
   }                                                                           \
-}                                                                             \
+
 
 bool translate_block_arm(u32 pc, bool ram_region)
 {
@@ -3037,6 +3036,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
     pc_address_block = load_gamepak_page(pc_region & 0x3FF);
 
   if (ram_region) {
+    update_pc_limits();
     translation_ptr = ram_translation_ptr;
     translation_cache_limit = &ram_translation_cache[
        RAM_TRANSLATION_CACHE_SIZE - TRANSLATION_CACHE_LIMIT_THRESHOLD
@@ -3092,7 +3092,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
       arm_process_cheats();
     }
 
-    update_pc_limits();
+    // update_pc_limits();
     translate_arm_instruction();
     block_data_position++;
 
@@ -3152,8 +3152,11 @@ bool translate_block_arm(u32 pc, bool ram_region)
     }
   }
 
-  if (ram_region)
-    ram_translation_ptr = translation_ptr;
+  if (ram_region) 
+  {
+    update_pc_limits();
+    ram_translation_ptr = translation_ptr; 
+  }
   else
     rom_translation_ptr = translation_ptr;
 
@@ -3201,6 +3204,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
     pc_address_block = load_gamepak_page(pc_region & 0x3FF);
 
   if (ram_region) {
+    update_pc_limits();
     translation_ptr = ram_translation_ptr;
     translation_cache_limit = &ram_translation_cache[
        RAM_TRANSLATION_CACHE_SIZE - TRANSLATION_CACHE_LIMIT_THRESHOLD
@@ -3253,7 +3257,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
       thumb_process_cheats();
     }
 
-    update_pc_limits();
+    // update_pc_limits();
     translate_thumb_instruction();
     block_data_position++;
 
@@ -3309,8 +3313,11 @@ bool translate_block_thumb(u32 pc, bool ram_region)
     }
   }
 
-  if (ram_region)
-    ram_translation_ptr = translation_ptr;
+  if (ram_region) 
+  {
+    update_pc_limits();
+    ram_translation_ptr = translation_ptr; 
+  }
   else
     rom_translation_ptr = translation_ptr;
 


### PR DESCRIPTION
This partially reverts commit 8036ad5 which broke the audio in dynarecs on CT Special Forces 3.  Essentially restoring the setting of the IWRAM/EWRAM thresholds back to the original positions in the code, but keeping the other changes in 8036ad5.

Applying this PR restores the working audio in this game.

Up to @davidgfnet if this is satisfactory to commit or not without further investigation - I think the intention was to track the thresholds before each block translation.