### PR TITLE
DRAFT - OAM Order Hijack Support (to fix #227 and similar)

### DIFF
--- a/video.cc
+++ b/video.cc
@@ -1085,10 +1085,10 @@ static inline void render_obj_tile_Nbpp(u32 px_comb,
    
   }else {
     u32 tilepix = eswap32(*(u32*)tile_ptr);
+    const u16 *subpal = &pal[palette];
     if (tilepix) {   // Can skip all pixels if the row is just transparent
       for (u32 i = 0; i < 8; i++, dest_ptr++) {
         u8 pval = (hflip ? (tilepix >> ((7-i)*4)) : (tilepix >> (i*4))) & 0xF;
-        const u16 *subpal = &pal[palette];
         if (pval) {
           if (rdtype == FULLCOLOR)
             *dest_ptr = subpal[pval];
@@ -1104,7 +1104,26 @@ static inline void render_obj_tile_Nbpp(u32 px_comb,
             *dest_ptr = dest_ptr[240];
         }
       }
-    }
+    } else 
+        {
+        // As this half-row is blank, check the Object Buffer for pixels
+        for (u32 i = 0; i < 8; i++, dest_ptr++, sl_start++) {
+          //u8 curr_pos = (u16*)dest_ptr - get_screen_pixels();
+          if(obj_buf[sl_start]) {
+            if (rdtype == FULLCOLOR)
+              *dest_ptr = subpal[(u8) obj_buf[sl_start]];
+            else if (rdtype == INDXCOLOR)
+              *dest_ptr = obj_buf[sl_start];
+            else if (rdtype == STCKCOLOR) {
+              if (*dest_ptr & 0x100)
+                *dest_ptr = obj_buf[sl_start] | ((*dest_ptr) & 0xFFFF0000);
+              else
+                *dest_ptr = obj_buf[sl_start] | ((*dest_ptr) << 16);
+            }
+            //*dest_ptr = obj_buf[sl_start];
+          }
+        }
+      }
   }
 }
 
@@ -1917,7 +1936,10 @@ void tile_render_layers(u32 start, u32 end, dsttype *dst_ptr, u32 enabled_layers
        bool is_obj = layer & 0x4;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, read_ioreg(REG_VCOUNT));
-         // Use u16/INDXCOLOR mode to give us best flexibility when replacing pixels across all modes 
+         // TODO: Currently hard coded to full color only so no blending etc
+         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
+         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
+         // below if it's enabled
          render_scanline_objs<u16, INDXCOLOR>(layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
          //for(u8 c = 0; c < 240; c++) {
          //   if(obj_buf[c])
@@ -2133,7 +2155,10 @@ static void bitmap_render_layers(
        bool obj_enabled = enable_flags & 0x10;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, REG_VCOUNT);
-         // Use u16/INDXCOLOR mode to give us best flexibility when replacing pixels across all modes 
+         // TODO: Currently hard coded to full color only so no blending etc
+         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
+         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
+         // below if it's enabled
          render_scanline_objs<dsttype, FULLCOLOR>(current_layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
        }
      }

--- a/video.cc
+++ b/video.cc
@@ -1917,10 +1917,7 @@ void tile_render_layers(u32 start, u32 end, dsttype *dst_ptr, u32 enabled_layers
        bool is_obj = layer & 0x4;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, read_ioreg(REG_VCOUNT));
-         // TODO: Currently hard coded to full color only so no blending etc
-         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
-         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
-         // below if it's enabled
+         // Use u16/INDXCOLOR mode to give us best flexibility when replacing pixels across all modes 
          render_scanline_objs<u16, INDXCOLOR>(layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
          //for(u8 c = 0; c < 240; c++) {
          //   if(obj_buf[c])

--- a/video.cc
+++ b/video.cc
@@ -1106,7 +1106,7 @@ static inline void render_obj_tile_Nbpp(u32 px_comb,
       }
     } else 
         {
-        // As this half-row is blank, check the Object Buffer for pixels
+        // As this full-row is blank, check the Object Buffer for pixels
         for (u32 i = 0; i < 8; i++, dest_ptr++, sl_start++) {
           //u8 curr_pos = (u16*)dest_ptr - get_screen_pixels();
           if(obj_buf[sl_start]) {
@@ -1927,7 +1927,7 @@ void tile_render_layers(u32 start, u32 end, dsttype *dst_ptr, u32 enabled_layers
   // Clear the object buffer
   memset(obj_buf, 0, sizeof(obj_buf));
 
-  // If this line has OAM hijack we need to clear the object buffer and fill it
+  // If this line has OAM hijack we need to fill the buffer with OBJ layers
   // first so that the buffer is available to overlay pixels onto transparent OBJ areas
   if (row_obj_hijack) {
      // Fill it with Object Layers only, back to front
@@ -1936,10 +1936,7 @@ void tile_render_layers(u32 start, u32 end, dsttype *dst_ptr, u32 enabled_layers
        bool is_obj = layer & 0x4;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, read_ioreg(REG_VCOUNT));
-         // TODO: Currently hard coded to full color only so no blending etc
-         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
-         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
-         // below if it's enabled
+         // Render to u16/INDXCOLOR to allow us to cover all render types when substituting pixels 
          render_scanline_objs<u16, INDXCOLOR>(layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
          //for(u8 c = 0; c < 240; c++) {
          //   if(obj_buf[c])
@@ -2145,7 +2142,7 @@ static void bitmap_render_layers(
   // Clear the object buffer
   memset(obj_buf, 0, sizeof(obj_buf));
 
-  // If this line has OAM hijack we need to clear the object buffer and fill it
+  // If this line has OAM hijack we need to fill the buffer with OBJ layers 
   // first so that the buffer is available to overlay pixels onto transparent OBJ areas
   if (row_obj_hijack) {
      // Fill it with Object Layers only, back to front
@@ -2155,10 +2152,7 @@ static void bitmap_render_layers(
        bool obj_enabled = enable_flags & 0x10;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, REG_VCOUNT);
-         // TODO: Currently hard coded to full color only so no blending etc
-         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
-         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
-         // below if it's enabled
+         // Render to u16/INDXCOLOR to allow us to cover all render types when substituting pixels 
          render_scanline_objs<dsttype, FULLCOLOR>(current_layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
        }
      }

--- a/video.cc
+++ b/video.cc
@@ -1472,6 +1472,10 @@ void render_scanline_objs(
   u32 objcnt = obj_priority_count[priority][vcount];
   u8 *objlist = obj_priority_list[priority][vcount];
 
+  // Clear the object buffer for Priority 0
+  if(priority == 0)
+    memset(obj_buf, 0, sizeof(obj_buf));
+
   // Render all the visible objects for this priority (back to front)
   for (objn = objcnt-1; objn >= 0; objn--) {
     // Objects in the list are pre-filtered and sorted in the appropriate order

--- a/video.cc
+++ b/video.cc
@@ -2133,10 +2133,7 @@ static void bitmap_render_layers(
        bool obj_enabled = enable_flags & 0x10;
        if (is_obj && obj_enabled) {
          //printf("Start: %d, End: %d, Row: %d \n", start, end, REG_VCOUNT);
-         // TODO: Currently hard coded to full color only so no blending etc
-         // Need to give this a bit of thought - I think OBJs don't blend with each other so this is correct,
-         // But technically I think correct behaviour would be that the buffer pixels should blend with the background layer 
-         // below if it's enabled
+         // Use u16/INDXCOLOR mode to give us best flexibility when replacing pixels across all modes 
          render_scanline_objs<dsttype, FULLCOLOR>(current_layer & 0x3, start, end, obj_buf_ptr, &palette_ram_converted[0x100]);
        }
      }


### PR DESCRIPTION
This is my attempt to support OAM Order Hijacking.  The cause and effect of this is outlined in issue #227.

The issue that I see for gpsp in addressing this issue is that we store the Layer Priority at the Object/BG levels only.  In order to correctly deal with OAM Order Hijacking in the same way as the hardware, we need to be able to check priority at a pixel-level and act accordingly.

My solution here is - 

a) to check for OAM Order Hijacking at a row-level when we are ordering our objects (in order_obj), and mark each applicable row in the same way we do for rows that contain transparent objects. 

b) when we come to render a scanline marked as hijacked, generate an OBJ-only scanline buffer first by rendering all available OBJ layers to this buffer in u16/INDXCOLOR mode, which gives us the most flexibility later on 

c) when rendering 8-bit per pixel OBJ tiles, we check 4 pixels at a time for transparency (tilepix).  In the current code, if all 4 pixels are transparent (i.e. 0), we move on to the next 4 pixels to complete the tile.  But in my PR, we instead check each pixel to see if we have a non-zero value in the OBJ scanline buffer we created.  If we do, we render the value to dest_ptr using the selected render mode.

I have tried to build in some optimisations here such as only creating the OBJ scanline buffer on scanlines affected by a hijack and only comparing to the scanline buffer when we have 4 consecutive transparent pixels as described above.  The latter is sufficient to address the issues identified in Golden Sun as far as I can see, but complete/correct emulation would be to compare against EVERY transparent pixel.  

Further ToDos:
- 4bpp support (Now DONE - this also fixes areas in Golden Sun 2 and Zelda Minish Cap!) 
- Affine/Mosaic Objects support
- Partial tile support - at the moment I'm only applying the buffer to full tiles, so tiles cut off by the screen on either side will still exhibit the previous behaviour

So this PR is still in draft at the moment for more discussion/testing before committing.