### PR TITLE
Separate MAX_BLOCK_SIZE / MAX_EXITS for arm/thumb mode and reduce arm…

### DIFF
--- a/cpu_threaded.c
+++ b/cpu_threaded.c
@@ -2884,11 +2884,14 @@ u8 function_cc *block_lookup_address_thumb(u32 pc)
   }                                                                           \
 }                                                                             \
 
-#define MAX_BLOCK_SIZE   1024   // 2/4KiB blocks max
-#define MAX_EXITS          32   // This covers 99% blocks
+#define thumb_MAX_BLOCK_SIZE   1024   // 2/4KiB blocks max
+#define thumb_MAX_EXITS          32   // This covers 99% blocks
+#define arm_MAX_BLOCK_SIZE       32   // Smaller values for ARM mode
+#define arm_MAX_EXITS             4   // Smaller values for ARM mode
 
-block_data_type block_data[MAX_BLOCK_SIZE];
-block_exit_type block_exits[MAX_EXITS];
+// Set array sizes to largest values i.e. thumb
+block_data_type block_data[thumb_MAX_BLOCK_SIZE];
+block_exit_type block_exits[thumb_MAX_EXITS];
 
 #define smc_write_arm_yes() {                                                 \
   intptr_t offset = (pc < 0x03000000) ? 0x40000 : -0x8000;                    \
@@ -2964,7 +2967,7 @@ block_exit_type block_exits[MAX_EXITS];
         if(i < 0)                                                             \
           break;                                                              \
       }                                                                       \
-      if(block_exit_position == MAX_EXITS)                                    \
+      if(block_exit_position == type##_MAX_EXITS)                             \
         break;                                                                \
     }                                                                         \
     else                                                                      \
@@ -2980,7 +2983,7 @@ block_exit_type block_exits[MAX_EXITS];
                                                                               \
     block_data[block_data_position].update_cycles = 0;                        \
     block_data_position++;                                                    \
-    if((block_data_position == MAX_BLOCK_SIZE) ||                             \
+    if((block_data_position == type##_MAX_BLOCK_SIZE) ||                      \
      (block_end_pc == 0x3007FF0) || (block_end_pc == 0x203FFFF0))             \
     {                                                                         \
       break;                                                                  \
@@ -3029,7 +3032,7 @@ bool translate_block_arm(u32 pc, bool ram_region)
   u8 *translation_cache_limit = NULL;
   s32 i;
   u32 flag_status;
-  block_exit_type external_block_exits[MAX_EXITS];
+  block_exit_type external_block_exits[arm_MAX_EXITS];
   generate_block_extra_vars_arm();
   arm_fix_pc();
 
@@ -3193,7 +3196,7 @@ bool translate_block_thumb(u32 pc, bool ram_region)
   u8 *translation_cache_limit = NULL;
   s32 i;
   u32 flag_status;
-  block_exit_type external_block_exits[MAX_EXITS];
+  block_exit_type external_block_exits[thumb_MAX_EXITS];
   generate_block_extra_vars_thumb();
   thumb_fix_pc();
 


### PR DESCRIPTION
… values

This improves performance on Camelot games (specifically Mario Tennis / Mario Golf) and solves issue #151.  Theory is that by reducing the block sizes/exits for arm mode that this reduces the number of times the dynarec caches need to be flushed per frame.  Impact of this change needs to be assessed for all games though.