### PR TITLE
Increase frequency of Interrupts/DMA instance checks during scanline

### DIFF
--- a/main.c
+++ b/main.c
@@ -262,7 +262,10 @@ u32 function_cc update_gba(int remaining_cycles)
 
     // Figure out when we need to stop CPU execution. The next event is
     // a video event or a timer event, whatever happens first.
-    execute_cycles = MAX(video_count, 0);
+    
+    // Set this low to increase frequency we check for interrupts during the scanline 
+    // but sync with video count once we get equal or below 96 cycles remaining
+    execute_cycles = MIN(video_count, 96);
     {
       u32 cc = serial_next_event();
       execute_cycles = MIN(execute_cycles, cc);


### PR DESCRIPTION
This resolves issue #224.  All games in this issue (all from the same developer) generate a high number of DMA/IRQ requests per scanline relative to other games.  Theory is that the default frequency (about once or twice per scanline) isn't enough for these to be fired in a timely fashion for these games, resulting in the graphics corruption reported in the issue.

This PR significantly reduces the number of cycles that are run before update_gba is called to check for DMA/IRQ status, which resolves the corrupted graphics.  Casual testing with other games hasn't shown any side affects but full impact testing with other games will be needed.