### PR TITLE
allow passing additional argument for compile gpSP with 60FPS overclock for any platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ ifeq ($(FORCE_32BIT_ARCH),1)
 	FORCE_32BIT := -m32
 endif
 
+# check if user compiles a 60 FPS overclock version
+ifeq ($(OVERCLOCK_60FPS),1)
+	CFLAGS += -DOVERCLOCK_60FPS
+endif
+
 # system platform
 system_platform = unix
 ifeq ($(shell uname -a),)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DEBUG=0
+OVERCLOCK_60FPS ?= 0
 FRONTEND_SUPPORTS_RGB565=1
 FORCE_32BIT_ARCH=0
 MMAP_JIT_CACHE=0
@@ -37,11 +38,6 @@ FORCE_32BIT :=
 
 ifeq ($(FORCE_32BIT_ARCH),1)
 	FORCE_32BIT := -m32
-endif
-
-# check if user compiles a 60 FPS overclock version
-ifeq ($(OVERCLOCK_60FPS),1)
-	CFLAGS += -DOVERCLOCK_60FPS
 endif
 
 # system platform
@@ -248,7 +244,7 @@ else ifeq ($(platform), vita)
 	CC = arm-vita-eabi-gcc$(EXE_EXT)
 	CXX = arm-vita-eabi-g++$(EXE_EXT)
 	AR = arm-vita-eabi-ar$(EXE_EXT)
-	CFLAGS += -DVITA -DOVERCLOCK_60FPS
+	CFLAGS += -DVITA
 	CFLAGS += -marm -mcpu=cortex-a9 -mfloat-abi=hard
 	CFLAGS += -Wall -mword-relocations
 	CFLAGS += -fomit-frame-pointer -ffast-math
@@ -257,6 +253,7 @@ else ifeq ($(platform), vita)
 	ASFLAGS += -mcpu=cortex-a9
 	STATIC_LINKING = 1
 	HAVE_DYNAREC = 1
+	OVERCLOCK_60FPS = 1
 	CPU_ARCH := arm
 
 # CTR(3DS)
@@ -585,6 +582,11 @@ CFLAGS += $(DEFINES) $(COMMON_DEFINES)
 
 ifeq ($(FRONTEND_SUPPORTS_RGB565), 1)
 	CFLAGS += -DFRONTEND_SUPPORTS_RGB565
+endif
+
+# check if user compiles a 60 FPS overclock version
+ifeq ($(OVERCLOCK_60FPS),1)
+	CFLAGS += -DOVERCLOCK_60FPS
 endif
 
 


### PR DESCRIPTION
Currently, the 60 FPS overclock hack is only limited to PSVita.

But i think some other platforms can take advantage of the 60 FPS overclock.

What i did is add in the Makefile the ability of using the additional argument **OVERCLOCK_60FPS=1** for build (compile) gpSP with the 60FPS overclock hack for any platform.

To compile using the 60FPS overclock hack, run **make OVERCLOCK_60FPS=1**