### PR TITLE
Fix FPS Counter when Frame Skipping is on

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1273,7 +1273,8 @@ void retro_run(void)
    }
 
    audio_run();
-   video_run();
+   if (!skip_next_frame)
+     video_run();
 
    switch (serial_mode) {
    case SERIAL_MODE_RFU:


### PR DESCRIPTION
Frame skipping options were making no difference to FPS reported, this was due to video_run being called regardless of whether skip_next_frame had been set.