### PR TITLE
libretro: add selectable system-clock RTC source

### DIFF
--- a/gba_memory.c
+++ b/gba_memory.c
@@ -1265,6 +1265,15 @@ s32 rtc_bit_count;
  * rate, which would rewind the in-game clock every few minutes.
  * frame_counter wraps after ~2.27 years of continuous emulation. */
 static s64 rtc_base_time = 0;
+static rtc_time_source_type rtc_time_source = RTC_TIME_SOURCE_DETERMINISTIC;
+
+void rtc_set_time_source(rtc_time_source_type source)
+{
+  if (source != RTC_TIME_SOURCE_SYSTEM)
+    source = RTC_TIME_SOURCE_DETERMINISTIC;
+
+  rtc_time_source = source;
+}
 
 /* Cycles per frame at the native rate; same divisor at the 60FPS
  * overclock since GBC_BASE_RATE scales correspondingly. */
@@ -1280,6 +1289,9 @@ static void rtc_init_base_time(void)
 
 static time_t rtc_current_time(void)
 {
+  if (rtc_time_source == RTC_TIME_SOURCE_SYSTEM)
+    return time(NULL);
+
   return (time_t)(rtc_base_time +
                   (s64)((double)frame_counter * GBA_FRAME_SECONDS));
 }

--- a/gba_memory.h
+++ b/gba_memory.h
@@ -26,6 +26,12 @@
 #define FEAT_DISABLE      0
 #define FEAT_ENABLE       1
 
+typedef enum rtc_time_source_type
+{
+  RTC_TIME_SOURCE_DETERMINISTIC = 0,
+  RTC_TIME_SOURCE_SYSTEM
+} rtc_time_source_type;
+
 #define DMA_CHAN_CNT   4
 
 #define DMA_START_IMMEDIATELY         0
@@ -252,6 +258,7 @@ u32 load_gamepak(const struct retro_game_info* info, const char *name,
 s32 load_bios(char *name);
 void init_memory(void);
 void init_gamepak_buffer(void);
+void rtc_set_time_source(rtc_time_source_type source);
 bool gamepak_must_swap(void);
 void memory_term(void);
 u8 *load_gamepak_page(u32 physical_index);

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -944,6 +944,18 @@ static void check_variables(bool started_from_load)
    dynarec_enable = 0;
 #endif
 
+   var.key = "gpsp_rtc_time_source";
+   var.value = NULL;
+   {
+      rtc_time_source_type source = RTC_TIME_SOURCE_DETERMINISTIC;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value &&
+          !strcmp(var.value, "system"))
+         source = RTC_TIME_SOURCE_SYSTEM;
+
+      rtc_set_time_source(source);
+   }
+
    if (started_from_load) {
      var.key                = "gpsp_bios";
      var.value              = 0;

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -113,6 +113,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "auto"
    },
    {
+      "gpsp_rtc_time_source",
+      "RTC Time Source",
+      "Selects the clock used by RTC-enabled cartridges. Deterministic advances with emulated frames and is preserved in save states. System Clock follows the host clock, including time elapsed while content is not running.",
+      {
+         { "deterministic", "Deterministic" },
+         { "system",        "System Clock" },
+         { NULL, NULL },
+      },
+      "deterministic"
+   },
+   {
       "gpsp_serial",
       "Link Cable Connectivity",
       "Configures the serial (Link Cable) connection. Automatic will pick up a reasonable support for most known games.",


### PR DESCRIPTION
## Summary

Adds an RTC Time Source core option:

- Deterministic: preserves the existing baseline-plus-frame-counter behavior.
- System Clock: reads the host wall clock, including time elapsed while
  content is suspended or not running.

Deterministic remains the default to preserve existing savestate, movie,
and netplay behavior.

## Motivation

Always using deterministic emulated time is useful for reproducibility, but
time-based cartridge events do not advance while the emulator is stopped.
This is particularly noticeable on handheld devices used for Pokémon games.

This is related to [libretro/gpsp#275](https://github.com/libretro/gpsp/issues/275). It does not change RTC cartridge autodetection;
the existing RTC Support option still controls whether RTC hardware is enabled.

## Testing
- System-clock behavior tested through the NextUI on TRIMUI Brick Pro.